### PR TITLE
Add GUI launcher and improve import handling for package compatibility

### DIFF
--- a/launch_gui.py
+++ b/launch_gui.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""
+GUI Launcher for STL Processor
+Alternative launcher if entry points have issues
+"""
+import sys
+from pathlib import Path
+
+# Add src directory to Python path
+src_dir = Path(__file__).parent / "src"
+sys.path.insert(0, str(src_dir))
+
+if __name__ == "__main__":
+    try:
+        from gui import main
+        main()
+    except ImportError as e:
+        print(f"Error: Failed to import GUI module: {e}")
+        print("Please make sure all dependencies are installed:")
+        print("  pip install -r requirements.txt")
+        print("  pip install tkinterdnd2  # Optional, for drag & drop")
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)

--- a/src/core/dimension_extractor.py
+++ b/src/core/dimension_extractor.py
@@ -1,7 +1,16 @@
 import trimesh
 import numpy as np
 from typing import Dict, List, Union, Tuple, Optional
-from ..utils.logger import logger
+from pathlib import Path
+
+# Handle both package and direct imports
+try:
+    from ..utils.logger import logger
+except ImportError:
+    import sys
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    from utils.logger import setup_logger
+    logger = setup_logger("dimension_extractor")
 
 
 class DimensionExtractor:

--- a/src/core/mesh_validator.py
+++ b/src/core/mesh_validator.py
@@ -2,7 +2,16 @@ import trimesh
 import numpy as np
 from typing import Dict, List, Tuple, Optional, Any
 from enum import Enum
-from ..utils.logger import logger
+from pathlib import Path
+
+# Handle both package and direct imports
+try:
+    from ..utils.logger import logger
+except ImportError:
+    import sys
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    from utils.logger import setup_logger
+    logger = setup_logger("mesh_validator")
 
 
 class ValidationLevel(Enum):

--- a/src/core/stl_processor.py
+++ b/src/core/stl_processor.py
@@ -2,7 +2,15 @@ import trimesh
 from pathlib import Path
 from typing import Dict, Optional, Union
 import numpy as np
-from ..utils.logger import logger
+
+# Handle both package and direct imports
+try:
+    from ..utils.logger import logger
+except ImportError:
+    import sys
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    from utils.logger import setup_logger
+    logger = setup_logger("stl_processor")
 
 
 class STLProcessor:

--- a/src/gui.py
+++ b/src/gui.py
@@ -5,15 +5,34 @@ import threading
 import json
 from typing import Optional, Dict, Any
 import sys
+import os
 
-sys.path.insert(0, str(Path(__file__).parent))
+# Ensure we can import from the src directory
+current_dir = Path(__file__).parent
+if str(current_dir) not in sys.path:
+    sys.path.insert(0, str(current_dir))
 
-from core.stl_processor import STLProcessor
-from core.dimension_extractor import DimensionExtractor
-from core.mesh_validator import MeshValidator, ValidationLevel
-from rendering.vtk_renderer import VTKRenderer
-from rendering.base_renderer import MaterialType, LightingPreset
-from utils.logger import setup_logger
+# Also add parent directory to handle package imports
+parent_dir = current_dir.parent
+if str(parent_dir) not in sys.path:
+    sys.path.insert(0, str(parent_dir))
+
+try:
+    # Try package-style imports first
+    from src.core.stl_processor import STLProcessor
+    from src.core.dimension_extractor import DimensionExtractor
+    from src.core.mesh_validator import MeshValidator, ValidationLevel
+    from src.rendering.vtk_renderer import VTKRenderer
+    from src.rendering.base_renderer import MaterialType, LightingPreset
+    from src.utils.logger import setup_logger
+except ImportError:
+    # Fall back to direct imports
+    from core.stl_processor import STLProcessor
+    from core.dimension_extractor import DimensionExtractor
+    from core.mesh_validator import MeshValidator, ValidationLevel
+    from rendering.vtk_renderer import VTKRenderer
+    from rendering.base_renderer import MaterialType, LightingPreset
+    from utils.logger import setup_logger
 
 logger = setup_logger("stl_processor_gui")
 

--- a/src/rendering/base_renderer.py
+++ b/src/rendering/base_renderer.py
@@ -3,7 +3,15 @@ from pathlib import Path
 from typing import Dict, List, Tuple, Optional, Union, Any
 import numpy as np
 from enum import Enum
-from ..utils.logger import logger
+import sys
+
+# Handle both package and direct imports
+try:
+    from ..utils.logger import logger
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    from utils.logger import setup_logger
+    logger = setup_logger("base_renderer")
 
 
 class MaterialType(Enum):

--- a/src/rendering/vtk_renderer.py
+++ b/src/rendering/vtk_renderer.py
@@ -2,8 +2,17 @@ import vtk
 import numpy as np
 from pathlib import Path
 from typing import Tuple, Optional
-from .base_renderer import BaseRenderer, MaterialType, LightingPreset, RenderQuality
-from ..utils.logger import logger
+import sys
+
+# Handle both package and direct imports
+try:
+    from .base_renderer import BaseRenderer, MaterialType, LightingPreset, RenderQuality
+    from ..utils.logger import logger
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    from rendering.base_renderer import BaseRenderer, MaterialType, LightingPreset, RenderQuality
+    from utils.logger import setup_logger
+    logger = setup_logger("vtk_renderer")
 
 
 class VTKRenderer(BaseRenderer):


### PR DESCRIPTION
## Summary
- Added a new `launch_gui.py` script to provide an alternative GUI launcher, improving usability when entry points have issues.
- Enhanced import handling across core modules (`dimension_extractor.py`, `mesh_validator.py`, `stl_processor.py`) and rendering modules to support both package-style and direct imports.
- Updated `gui.py` to robustly manage Python path and imports, ensuring compatibility in different execution contexts.

## Changes

### New Features
- **GUI Launcher Script**: Created `launch_gui.py` as a standalone entry point for launching the GUI, with error handling for missing dependencies and import failures.

### Core Module Updates
- Added fallback import logic in core modules (`dimension_extractor.py`, `mesh_validator.py`, `stl_processor.py`) to handle relative imports gracefully when run outside the package context.

### GUI Module Enhancements
- Improved sys.path management in `gui.py` to include current and parent directories.
- Added try-except blocks to attempt package-style imports first, falling back to direct imports if necessary.

### Rendering Module Updates
- Similar import fallback logic added to `base_renderer.py` and `vtk_renderer.py` to ensure logger and renderer classes are imported correctly regardless of execution context.

## Test plan
- [x] Verified that `launch_gui.py` successfully starts the GUI.
- [x] Tested GUI launch with and without entry points.
- [x] Confirmed no import errors occur when running modules directly or as part of the package.
- [x] Validated logger initialization in all updated modules.
- [x] Ran existing unit tests to ensure no regressions.

This PR improves the robustness and usability of the GUI launch process and enhances the codebase's flexibility in different runtime environments.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/17d0b4c8-536f-46f9-8a20-f50c1287fe40