### PR TITLE
Update drop area border style in GUI

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -102,7 +102,7 @@ class STLProcessorGUI:
         
         self.drop_area = tk.Label(drop_frame, text="Drop STL files here", 
                                  bg="lightgray", fg="gray", 
-                                 border=2, relief="dashed", height=3)
+                                 border=2, relief="ridge", height=3)
         self.drop_area.grid(row=0, column=0, sticky=(tk.W, tk.E))
         
     def create_notebook(self):


### PR DESCRIPTION
## Summary
- Changed the border style of the drop area in the GUI from "dashed" to "ridge" for improved visual appearance

## Changes

### GUI Component
- Modified the `drop_area` label in `src/gui.py` to use `relief="ridge"` instead of `relief="dashed"`

## Test plan
- [ ] Verify the drop area border appears with a ridge style
- [ ] Ensure no other GUI functionality is affected by this change

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/17d0b4c8-536f-46f9-8a20-f50c1287fe40