### PR TITLE
Fix mesh validation logic to use is_volume instead of is_valid

### DIFF
--- a/src/core/dimension_extractor.py
+++ b/src/core/dimension_extractor.py
@@ -114,7 +114,7 @@ class DimensionExtractor:
                 "min_face_area": float(np.min(face_areas)) if len(face_areas) > 0 else 0.0,
                 "max_face_area": float(np.max(face_areas)) if len(face_areas) > 0 else 0.0,
                 "avg_face_area": float(np.mean(face_areas)) if len(face_areas) > 0 else 0.0,
-                "is_valid": bool(self.mesh.is_valid),
+                "is_valid": bool(self.mesh.is_volume),
                 "is_convex": bool(self.mesh.is_convex)
             }
         except Exception as e:

--- a/src/core/mesh_validator.py
+++ b/src/core/mesh_validator.py
@@ -181,8 +181,8 @@ class MeshValidator:
             if not self.mesh.is_watertight:
                 self._add_issue("warning", "not_watertight", "Mesh is not watertight")
                 
-            if not self.mesh.is_valid:
-                self._add_issue("warning", "not_valid", "Mesh fails trimesh validity check")
+            if not self.mesh.is_volume:
+                self._add_issue("warning", "not_valid", "Mesh does not represent a valid volume")
                 
         except Exception as e:
             self._add_issue("warning", "manifold_check_failed", f"Manifold check failed: {e}")
@@ -247,9 +247,9 @@ class MeshValidator:
         """Check for self-intersections (computationally expensive)."""
         try:
             # This is a basic check - full self-intersection detection is complex
-            if hasattr(self.mesh, 'is_valid') and not self.mesh.is_valid:
+            if not self.mesh.is_volume:
                 self._add_issue("warning", "potential_self_intersection", 
-                              "Mesh may have self-intersections")
+                              "Mesh may have self-intersections or invalid volume")
                 
         except Exception as e:
             self._add_issue("warning", "intersection_check_failed", f"Self-intersection check failed: {e}")
@@ -300,7 +300,7 @@ class MeshValidator:
                 "face_count": len(self.mesh.faces),
                 "edge_count": len(self.mesh.edges) if hasattr(self.mesh, 'edges') else None,
                 "is_watertight": bool(self.mesh.is_watertight),
-                "is_valid": bool(self.mesh.is_valid),
+                "is_valid": bool(self.mesh.is_volume),
                 "volume": float(self.mesh.volume) if self.mesh.is_volume else None,
                 "surface_area": float(self.mesh.area),
                 "bounding_box": self.mesh.bounds.tolist()

--- a/src/core/stl_processor.py
+++ b/src/core/stl_processor.py
@@ -80,7 +80,7 @@ class STLProcessor:
             logger.info(f"Mesh stats: {len(self.mesh.vertices)} vertices, {len(self.mesh.faces)} faces")
             
             # Check and fix mesh issues
-            if not self.mesh.is_valid:
+            if not self.mesh.is_volume:
                 logger.warning("Mesh has integrity issues, attempting repairs")
                 
                 # Fix normals
@@ -97,7 +97,7 @@ class STLProcessor:
                     self.mesh.fill_holes()
             
             # Final validity check
-            is_valid = self.mesh.is_valid
+            is_valid = self.mesh.is_volume
             if is_valid:
                 logger.info("Mesh validation successful")
             else:
@@ -135,7 +135,7 @@ class STLProcessor:
                 "bounding_box_min": self.mesh.bounds[0].tolist(),
                 "bounding_box_max": self.mesh.bounds[1].tolist(),
                 "is_watertight": bool(self.mesh.is_watertight),
-                "is_valid": bool(self.mesh.is_valid),
+                "is_valid": bool(self.mesh.is_volume),
                 "vertex_count": int(len(self.mesh.vertices)),
                 "face_count": int(len(self.mesh.faces))
             }


### PR DESCRIPTION
## Summary
- Corrects mesh validation checks by replacing `is_valid` with `is_volume` to better reflect mesh volume validity
- Updates dimension extraction, mesh validation, and STL processing modules accordingly
- Improves accuracy of mesh integrity warnings and validation status

## Changes

### Dimension Extractor
- Changed validity check from `self.mesh.is_valid` to `self.mesh.is_volume` for mesh validity reporting

### Mesh Validator
- Replaced `is_valid` checks with `is_volume` to determine if mesh represents a valid volume
- Updated warning messages to reflect volume validity instead of generic validity
- Adjusted self-intersection checks to consider volume validity
- Updated mesh info dictionary to use `is_volume` for validity and volume presence

### STL Processor
- Modified mesh integrity checks to use `is_volume` instead of `is_valid`
- Updated final validity check and logging to reflect volume-based validation
- Changed mesh info dictionary to report validity based on `is_volume`

## Test plan
- Verified mesh validation warnings trigger correctly for non-volume meshes
- Confirmed mesh stats and validity flags reflect volume status
- Tested STL processing repair attempts and final validation logging
- Ensured no regressions in mesh dimension extraction and reporting

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/8e39b0ab-6b06-4876-875d-608d9e6cf15c