### PR TITLE
Fix relative imports for logger module across multiple files

### DIFF
--- a/src/core/dimension_extractor.py
+++ b/src/core/dimension_extractor.py
@@ -3,7 +3,7 @@ import numpy as np
 from typing import Dict, List, Union, Tuple, Optional
 from pathlib import Path
 
-from ..utils.logger import logger
+from utils.logger import logger
 
 
 class DimensionExtractor:

--- a/src/core/mesh_validator.py
+++ b/src/core/mesh_validator.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Tuple, Optional, Any
 from enum import Enum
 from pathlib import Path
 
-from ..utils.logger import logger
+from utils.logger import logger
 
 
 class ValidationLevel(Enum):

--- a/src/core/stl_processor.py
+++ b/src/core/stl_processor.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Dict, Optional, Union
 import numpy as np
 
-from ..utils.logger import logger
+from utils.logger import logger
 
 
 class STLProcessor:

--- a/src/rendering/base_renderer.py
+++ b/src/rendering/base_renderer.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Tuple, Optional, Union, Any
 import numpy as np
 from enum import Enum
 
-from ..utils.logger import logger
+from utils.logger import logger
 
 
 class MaterialType(Enum):

--- a/src/rendering/vtk_renderer.py
+++ b/src/rendering/vtk_renderer.py
@@ -3,8 +3,8 @@ import numpy as np
 from pathlib import Path
 from typing import Tuple, Optional
 
-from .base_renderer import BaseRenderer, MaterialType, LightingPreset, RenderQuality
-from ..utils.logger import logger
+from rendering.base_renderer import BaseRenderer, MaterialType, LightingPreset, RenderQuality
+from utils.logger import logger
 
 
 class VTKRenderer(BaseRenderer):

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,6 +1,6 @@
 """Utility modules."""
 
-from .logger import setup_logger, logger
+from utils.logger import setup_logger, logger
 
 __all__ = [
     "setup_logger",


### PR DESCRIPTION
## Summary
- Corrects import statements for the `logger` module to use absolute imports
- Updates import paths in core and rendering modules for consistency

## Changes

### Core Modules
- Changed `logger` import from relative (`..utils.logger`) to absolute (`utils.logger`) in:
  - `dimension_extractor.py`
  - `mesh_validator.py`
  - `stl_processor.py`

### Rendering Modules
- Updated `logger` import in `base_renderer.py` to absolute import
- Fixed imports in `vtk_renderer.py`:
  - Changed `base_renderer` import to absolute path `rendering.base_renderer`
  - Changed `logger` import to absolute `utils.logger`

### Utilities
- Corrected import in `src/utils/__init__.py` to use absolute import for `logger` and `setup_logger`

## Test plan
- [x] Verify that all modules correctly import the `logger` without import errors
- [x] Run existing unit tests to ensure no breakage due to import changes
- [x] Manual testing of core and rendering functionalities to confirm logger usage works as expected

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7dcfe64d-4517-4325-b98f-06a510374dfa