### PR TITLE
Fix file dialog parameter for default filename in error report saving

### DIFF
--- a/src/error_dialog.py
+++ b/src/error_dialog.py
@@ -566,7 +566,7 @@ class ComprehensiveErrorDialog:
                 title="Save Error Log",
                 defaultextension=".log",
                 filetypes=[("Log files", "*.log"), ("Text files", "*.txt"), ("All files", "*.*")],
-                initialname=default_filename
+                initialfile=default_filename
             )
             
             if file_path:
@@ -636,7 +636,7 @@ class ComprehensiveErrorDialog:
                 title="Save Error Report",
                 defaultextension=".txt",
                 filetypes=[("Text files", "*.txt"), ("All files", "*.*")],
-                initialname=default_filename
+                initialfile=default_filename
             )
             
             if file_path:


### PR DESCRIPTION
## Summary
- Corrects the parameter name for setting the default filename in file save dialogs
- Fixes issue where the default filename was not properly set when saving error logs and reports

## Changes

### Error Dialog
- Updated `initialname` to `initialfile` in `filedialog.asksaveasfilename` calls for both error log and error report saving dialogs

## Test plan
- [x] Open error log save dialog and verify the default filename is correctly pre-filled
- [x] Open error report save dialog and verify the default filename is correctly pre-filled
- [x] Save files and confirm they are saved with the expected default names

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b8066c21-9fff-48d7-9e74-a162cb636853