### PR TITLE
Refactor STL mesh validation to basic structure checks only

### DIFF
--- a/src/core/stl_processor.py
+++ b/src/core/stl_processor.py
@@ -65,10 +65,10 @@ class STLProcessor:
     
     def validate(self) -> bool:
         """
-        Validate mesh integrity and attempt repairs.
+        Perform basic validation on mesh structure only.
         
         Returns:
-            bool: True if mesh is valid or successfully repaired
+            bool: True if mesh has basic structure (vertices and faces)
         """
         if self.mesh is None:
             error_msg = "No mesh loaded for validation"
@@ -77,7 +77,7 @@ class STLProcessor:
             return False
             
         try:
-            logger.info("Validating mesh integrity")
+            logger.info("Performing basic mesh validation")
             
             # Check if mesh is empty
             if len(self.mesh.vertices) == 0 or len(self.mesh.faces) == 0:
@@ -86,39 +86,20 @@ class STLProcessor:
                 self.last_error = Exception(error_msg)
                 return False
             
-            # Log mesh stats
-            logger.info(f"Mesh stats: {len(self.mesh.vertices)} vertices, {len(self.mesh.faces)} faces")
-            
-            # Check and fix mesh issues
-            if not self.mesh.is_volume:
-                logger.warning("Mesh has integrity issues, attempting repairs")
-                
-                # Fix normals
-                self.mesh.fix_normals()
-                
-                # Remove duplicate faces
-                self.mesh.remove_duplicate_faces()
-                
-                # Remove degenerate faces
-                self.mesh.remove_degenerate_faces()
-                
-                # Fill holes if possible
-                if hasattr(self.mesh, 'fill_holes'):
-                    self.mesh.fill_holes()
-            
-            # Final validity check
-            is_valid = self.mesh.is_volume
-            if is_valid:
-                logger.info("Mesh validation successful")
-            else:
-                error_msg = "Mesh still has integrity issues after repair attempts - not a valid watertight volume"
-                logger.warning(error_msg)
+            # Check for minimum viable mesh
+            if len(self.mesh.vertices) < 3:
+                error_msg = "Mesh has fewer than 3 vertices"
+                logger.error(error_msg)
                 self.last_error = Exception(error_msg)
-                
-            return is_valid
+                return False
+            
+            # Log mesh stats
+            logger.info(f"Basic validation passed: {len(self.mesh.vertices)} vertices, {len(self.mesh.faces)} faces")
+            
+            return True
             
         except Exception as e:
-            logger.error(f"Error during mesh validation: {e}")
+            logger.error(f"Error during basic mesh validation: {e}")
             self.last_error = e
             return False
     


### PR DESCRIPTION
## Summary
- Simplifies the `validate` method in `STLProcessor` to perform only basic mesh structure validation
- Removes previous attempts to repair mesh integrity issues
- Adds checks for minimum viable mesh (at least 3 vertices)
- Updates logging to reflect the new validation scope

## Changes

### Core Functionality
- **Validation Logic**: Changed from validating and repairing mesh integrity to only verifying the presence of vertices and faces
- **Error Handling**: Added explicit error for meshes with fewer than 3 vertices
- **Logging**: Adjusted log messages to indicate basic validation status instead of repair attempts
- **Removed Repair Steps**: Eliminated mesh fixes such as normal correction, duplicate and degenerate face removal, and hole filling

## Test plan
- [x] Validate meshes with no vertices or faces are rejected
- [x] Validate meshes with fewer than 3 vertices are rejected
- [x] Validate meshes with sufficient vertices and faces pass basic validation
- [x] Confirm no repair attempts are made during validation
- [x] Check logs for appropriate validation messages

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/3cfc9ad4-b181-410a-9875-9c1881f27eff