### PR TITLE
Fix render window resizing and off-screen rendering in VTKRenderer

### DIFF
--- a/src/rendering/vtk_renderer.py
+++ b/src/rendering/vtk_renderer.py
@@ -29,7 +29,7 @@ class VTKRenderer(BaseRenderer):
     def initialize(self) -> bool:
         """Initialize VTK rendering system."""
         try:
-            logger.info("Initializing VTK renderer")
+            logger.info(f"Initializing VTK renderer with size: {self.width}x{self.height}")
             
             # Create renderer
             self.renderer = vtk.vtkRenderer()
@@ -37,12 +37,19 @@ class VTKRenderer(BaseRenderer):
             
             # Create render window
             self.render_window = vtk.vtkRenderWindow()
-            self.render_window.SetSize(self.width, self.height)
+            self.render_window.SetOffScreenRendering(1)  # Enable off-screen rendering first
+            self.render_window.SetSize(self.width, self.height)  # Set size after off-screen rendering
             self.render_window.AddRenderer(self.renderer)
-            self.render_window.SetOffScreenRendering(1)  # Enable off-screen rendering
+            
+            # Force the window size to be set correctly
+            self.render_window.Modified()
             
             # Create camera
             self.camera = self.renderer.GetActiveCamera()
+            
+            # Verify initialization
+            actual_size = self.render_window.GetSize()
+            logger.debug(f"VTK render window initialized with actual size: {actual_size[0]}x{actual_size[1]}")
             
             self.is_initialized = True
             logger.info("VTK renderer initialized successfully")
@@ -200,8 +207,16 @@ class VTKRenderer(BaseRenderer):
             # Ensure output directory exists
             output_path.parent.mkdir(parents=True, exist_ok=True)
             
+            # Ensure render window size is set correctly before rendering
+            self.render_window.SetSize(self.width, self.height)
+            logger.debug(f"Set render window size to: {self.width} x {self.height}")
+            
             # Render
             self.render_window.Render()
+            
+            # Verify the actual window size after rendering
+            actual_size = self.render_window.GetSize()
+            logger.debug(f"Actual render window size after render: {actual_size[0]} x {actual_size[1]}")
             
             # Capture screenshot
             window_to_image = vtk.vtkWindowToImageFilter()
@@ -236,8 +251,16 @@ class VTKRenderer(BaseRenderer):
                 logger.error("Render window not initialized")
                 return None
             
+            # Ensure render window size is set correctly before rendering
+            self.render_window.SetSize(self.width, self.height)
+            logger.debug(f"Set render window size to: {self.width} x {self.height}")
+            
             # Render
             self.render_window.Render()
+            
+            # Verify the actual window size after rendering
+            actual_size = self.render_window.GetSize()
+            logger.debug(f"Actual render window size after render: {actual_size[0]} x {actual_size[1]}")
             
             # Capture to VTK image
             window_to_image = vtk.vtkWindowToImageFilter()


### PR DESCRIPTION
## Summary
- Fixes render window resizing issues in the VTKRenderer class
- Ensures off-screen rendering is enabled before setting window size
- Adds debug logging for render window size before and after rendering

## Changes

### VTKRenderer Initialization
- Log the intended render window size during initialization
- Enable off-screen rendering before setting the window size
- Call `Modified()` on the render window to force size update
- Add debug logs to verify actual window size after initialization

### Rendering Methods
- Set the render window size explicitly before each render call
- Add debug logs to confirm the actual window size after rendering

## Test plan
- Verify that the render window size matches the expected dimensions during initialization
- Confirm that rendering output respects the specified window size
- Check debug logs for correct size settings before and after rendering
- Ensure no regressions in off-screen rendering functionality

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5013abae-3cb6-4321-aef7-f160b607957f