### PR TITLE
Fix render window resize and improve layout in STLProcessorGUI

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -81,8 +81,8 @@ class STLProcessorGUI:
     def __init__(self, root):
         self.root = root
         self.root.title("STL Listing Tool")
-        self.root.geometry("1200x800")
-        self.root.minsize(800, 600)
+        self.root.geometry("1400x900")
+        self.root.minsize(1000, 700)
         
         self.current_file = None
         self.processor = None
@@ -222,7 +222,7 @@ class STLProcessorGUI:
         self.notebook.add(self.rendering_frame, text="Rendering")
         
         self.rendering_frame.columnconfigure(1, weight=1)
-        self.rendering_frame.rowconfigure(3, weight=1)
+        self.rendering_frame.rowconfigure(2, weight=1)  # Make the render_display row expandable
         
         settings_frame = ttk.LabelFrame(self.rendering_frame, text="Render Settings", padding="10")
         settings_frame.grid(row=0, column=0, columnspan=2, sticky=(tk.W, tk.E), pady=(0, 10))
@@ -262,7 +262,7 @@ class STLProcessorGUI:
                   command=self.save_render).pack(side=tk.LEFT)
         
         self.render_display = tk.Label(self.rendering_frame, text="Rendered image will appear here",
-                                      bg="white", relief="sunken", width=60, height=20)
+                                      bg="white", relief="sunken", width=80, height=40)
         self.render_display.grid(row=2, column=0, columnspan=2, sticky=(tk.W, tk.E, tk.N, tk.S), pady=10)
         
         progress_frame = ttk.Frame(self.rendering_frame)


### PR DESCRIPTION
## Summary
- Adjusts the main window size and minimum size for better usability
- Fixes the row configuration in the rendering frame to make the render display expandable
- Increases the size of the render display widget for improved visibility

## Changes

### GUI Layout
- Increased main window geometry from 1200x800 to 1400x900
- Increased minimum window size from 800x600 to 1000x700
- Corrected row configuration in `rendering_frame` from row 3 to row 2 to make the render display row expandable
- Enlarged `render_display` label width from 60 to 80 and height from 20 to 40 for better display of rendered images

## Test plan
- [x] Verify window opens with new default size and minimum size constraints
- [x] Confirm render display expands correctly when resizing the window
- [x] Check that the render display area is larger and properly shows rendered images
- [x] Ensure no layout regressions in other parts of the GUI

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5013abae-3cb6-4321-aef7-f160b607957f