### PR TITLE
Use custom temp directory for rendering output in GUI

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -205,7 +205,12 @@ class STLProcessorGUI:
     
     def get_temp_render_path(self):
         """Get a safe temporary path for rendering output."""
-        temp_dir = Path(tempfile.gettempdir())
+        # Use custom temp directory for stl_listing_tools
+        if os.name == 'nt':  # Windows
+            temp_dir = Path(os.environ.get('LOCALAPPDATA', tempfile.gettempdir())) / "stl_listing_tools" / "tmp"
+        else:  # Unix-like systems
+            temp_dir = Path.home() / ".local" / "stl_listing_tools" / "tmp"
+        
         # Ensure the temp directory exists
         temp_dir.mkdir(parents=True, exist_ok=True)
         


### PR DESCRIPTION
## Summary
- Changed the temporary path for rendering output in the GUI to use a custom directory specific to `stl_listing_tools`.
- On Windows, the temp path is set under `%LOCALAPPDATA%\stl_listing_tools\tmp`.
- On Unix-like systems, the temp path is set under `~/.local/stl_listing_tools/tmp`.
- Ensures the custom temp directory exists before use.

## Changes

### GUI Module
- Modified `get_temp_render_path` method in `STLProcessorGUI` class:
  - Replaced default system temp directory with a custom path based on OS.
  - Added directory creation to ensure the path exists.

## Test plan
- [ ] Verify that the temp directory is correctly created on Windows and Unix-like systems.
- [ ] Confirm that rendering output is saved to the new custom temp directory.
- [ ] Check that no errors occur if the directory already exists or needs to be created.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/6407f828-16dc-4821-b6ed-44006ed19b8b